### PR TITLE
Package to enable pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include AUTHORS.md
+include LICENSE
+include README.md
+
+include requirements.txt
+recursive-include pathml/models/*.pt
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+albumentations
+joblib
+matplotlib
+pandas
+pyvips
+scikit-image
+scikit-learn
+shapely
+torch>=1.0,<=2.0
+torchvision>=0.5.0
+tqdm

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+"""The setup script."""
+
+from setuptools import setup, find_packages
+
+
+REQUIREMENTS_FILE = "requirements.txt"
+README_FILE = "README.md"
+
+# Requirements
+with open(REQUIREMENTS_FILE) as handle:
+    requirements = handle.read().strip().split("\n")
+
+with open(README_FILE) as readme_file:
+    readme = readme_file.read()
+
+setup(
+    name="pathml",
+    package="pathml",
+    packages=find_packages(),
+    use_scm_version={
+        "write_to": "pathml/_version.py",
+        "write_to_template": '__version__ = "{version}"\n',
+    },
+    author="Adam G. Berman, William R. Orchard, Marcel Gehrung, Florian Markowetz",
+    author_email="florian.markowetz@cruk.cam.ac.uk",
+    python_requires=">=3.7",
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
+    description="PathML: a Python library for deep learning on whole-slide images",
+    long_description=readme,
+    license="GNU General Public License v3",
+    include_package_data=True,
+    keywords=["pathology"],
+    setup_requires=["setuptools_scm"],
+    install_requires=requirements,
+    tests_require=requirements,
+    url="https://github.com/markowetzlab/pathml",
+    project_urls={
+        "Bug Tracker": "https://github.com/markowetzlab/pathml/issues",
+        "Documentation": "https://github.com/markowetzlab/pathml-tutorial",
+        "Source Code": "https://github.com/markowetzlab/pathml",
+    },
+    zip_safe=False,
+)


### PR DESCRIPTION
Hi, I wanted to try out the package but didn't want to set up Conda so I packaged the repository so that it can be installed with `pip`.
This should also make the tutorial easier to set up as it the `sys.path.append` calls would not be needed.

I added versioning using `setuptools_scm` which uses git tags and commits to automatically version the software.

Feel free to tailor further.
